### PR TITLE
Use python3

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -3,14 +3,14 @@
 set -euo pipefail
 
 main() {
-    python -m unittest
-    python -m examples.case_study
-    python -m examples.paper
-    python -m examples.plot_load_distribution --output "/tmp"
-    python -m examples.plot_node_loads --output "/tmp/load_nodes.pdf"
-    python -m examples.plot_workload_distribution \
+    python3 -m unittest
+    python3 -m examples.case_study
+    python3 -m examples.paper
+    python3 -m examples.plot_load_distribution --output "/tmp"
+    python3 -m examples.plot_node_loads --output "/tmp/load_nodes.pdf"
+    python3 -m examples.plot_workload_distribution \
         --output "/tmp/workload_distribution.pdf"
-    python -m examples.tutorial
+    python3 -m examples.tutorial
 }
 
 main


### PR DESCRIPTION
On some distros, python binary links to python2. The tests seem
to be expecting python3.