### PR TITLE
Fixes for type check errors exposed by pyright

### DIFF
--- a/examples/plot_workload_distribution.py
+++ b/examples/plot_workload_distribution.py
@@ -39,12 +39,12 @@ def main(output_filename: str) -> None:
     for fr in dist.keys():
         sigma = qs.strategy(read_fraction=fr)
         ys = [sigma.capacity(read_fraction=x) for x in xs]
-        ax.plot(xs, ys, '--', label=str(f'$\sigma_{{{fr}}}$'), linewidth=1,
+        ax.plot(xs, ys, '--', label=str(f'$\\sigma_{{{fr}}}$'), linewidth=1,
                 marker=next(markers), markevery=25, markersize=4, alpha=0.75)
 
     sigma = qs.strategy(read_fraction=dist)
     ys = [sigma.capacity(read_fraction=x) for x in xs]
-    ax.plot(xs, ys, label='$\sigma$', linewidth=1.5,
+    ax.plot(xs, ys, label='$\\sigma$', linewidth=1.5,
             marker=next(markers), markevery=25, markersize=4)
 
     ax.legend(ncol=3, loc='lower center', bbox_to_anchor=(0.5, 1.0))

--- a/quoracle/expr.py
+++ b/quoracle/expr.py
@@ -1,14 +1,17 @@
-from typing import Dict, Iterator, Generic, List, Optional, Set, TypeVar
+from typing import Any, Dict, Iterator, Generic, List, Optional, Protocol, Set, TypeVar
 import datetime
 import itertools
 import pulp
 
 
-T = TypeVar('T')
+class SupportsLessThan(Protocol):
+    def __lt__(self, __other: Any) -> bool: ...
+
+T = TypeVar("T", bound=SupportsLessThan)
 
 
-def _min_hitting_set(sets: Iterator[Set[T]]) -> int:
-    x_vars: Dict[T, pulp.LpVariable] = dict()
+def _min_hitting_set(sets: Iterator[Set]) -> int:
+    x_vars: Dict[Any, pulp.LpVariable] = dict()
     next_id = itertools.count()
 
     problem = pulp.LpProblem("min_hitting_set", pulp.LpMinimize)
@@ -130,6 +133,9 @@ class Node(Expr[T]):
 
     def __repr__(self) -> str:
         return f'Node({self.x})'
+
+    def __lt__(self, other) -> bool:
+        return self.x < other.x
 
     def quorums(self) -> Iterator[Set[T]]:
         yield {self.x}

--- a/quoracle/search.py
+++ b/quoracle/search.py
@@ -1,13 +1,10 @@
 from .distribution import Distribution
-from .expr import choose, Expr, Node
+from .expr import choose, Expr, Node, T
 from .quorum_system import (LATENCY, LOAD, NETWORK, NoStrategyFoundError,
                             QuorumSystem, Strategy, Tuple)
-from typing import Iterator, List, Optional, TypeVar
+from typing import Iterator, List, Optional
 import datetime
 import itertools
-
-
-T = TypeVar('T')
 
 
 class NoQuorumSystemFoundError(ValueError):

--- a/quoracle/viz.py
+++ b/quoracle/viz.py
@@ -1,16 +1,13 @@
 from . import distribution
 from . import geometry
 from .distribution import Distribution
-from .expr import Node
+from .expr import Node, T
 from .geometry import Point, Segment
 from .quorum_system import Strategy
 from typing import Dict, FrozenSet, List, Optional, Set, Tuple, TypeVar
 import collections
 import matplotlib
 import matplotlib.pyplot as plt
-
-
-T = TypeVar('T')
 
 
 def plot_node_load(filename: str,

--- a/tests/test_expr.py
+++ b/tests/test_expr.py
@@ -1,7 +1,7 @@
-from quoracle import *
-from quoracle.expr import *
-from typing import Any, FrozenSet
 import unittest
+
+from quoracle.expr import Expr, Node, choose
+from typing import Any, List, Set, FrozenSet
 
 class TestExpr(unittest.TestCase):
     def test_quorums(self):


### PR DESCRIPTION
Use SupportsLessThan to indicate that TypeVar T should be
comparable.